### PR TITLE
Search endpoint for prescriptions by patient name added

### DIFF
--- a/MediTrack/.idea/.gitignore
+++ b/MediTrack/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/MediTrack/.idea/misc.xml
+++ b/MediTrack/.idea/misc.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="MavenProjectsManager">
+    <option name="originalFiles">
+      <list>
+        <option value="$PROJECT_DIR$/pom.xml" />
+      </list>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_23" default="true" project-jdk-name="openjdk-23" project-jdk-type="JavaSDK" />
+</project>

--- a/MediTrack/.idea/vcs.xml
+++ b/MediTrack/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/MediTrack/src/controllers/PrescriptionController.java
+++ b/MediTrack/src/controllers/PrescriptionController.java
@@ -46,6 +46,18 @@ public class PrescriptionController {
             service.deletePrescription(req.params("id"));
             return "Prescription deleted.";
         });
+
+        // Get prescription by user name
+        get("/api/prescriptions/search", (req, res) -> {
+            String nameQuery = req.queryParams("name");
+            if (nameQuery == null || nameQuery.isEmpty()) {
+                res.status(400);
+                return "Query parameter 'name' is required.";
+            }
+            res.type("application/json");
+            return gson.toJson(service.searchPrescriptionsByPatientName(nameQuery));
+        });
+
     }
 }
 

--- a/MediTrack/src/repositories/PrescriptionRepository.java
+++ b/MediTrack/src/repositories/PrescriptionRepository.java
@@ -4,5 +4,6 @@ package repositories;
 import models.Prescription;
 
 public interface PrescriptionRepository extends Repository<Prescription, String> {
+    List<Prescription> searchByPatientName(String name);
 }
 

--- a/MediTrack/src/repositories/inmemory/InMemoryPrescriptionRepository.java
+++ b/MediTrack/src/repositories/inmemory/InMemoryPrescriptionRepository.java
@@ -3,6 +3,7 @@ package repositories.inmemory;
 
 import repositories.PrescriptionRepository;
 import models.Prescription;
+import java.util.stream.Collectors;
 
 import java.util.*;
 
@@ -28,5 +29,13 @@ public class InMemoryPrescriptionRepository implements PrescriptionRepository {
     public void delete(String id) {
         prescriptions.remove(id);
     }
-}
 
+    @Override
+    public List<Prescription> searchByPatientName(String name){
+        return prescriptions.values().stream()
+                .filter(p -> p.getPatient() != null &&
+                        p.getPatient().getName() != null &&
+                        p.getPatient().getName().toLowerCase().contains(name.toLowerCase()))
+                .collect(Collectors.toList());
+    }
+}

--- a/MediTrack/src/services/PrescriptionService.java
+++ b/MediTrack/src/services/PrescriptionService.java
@@ -36,4 +36,9 @@ public class PrescriptionService {
         prescription.setStatus("Verified");
         return prescriptionRepo.save(prescription);
     }
+
+    public List<Prescription> searchPrescriptionsByPatientName(String name) {
+        return prescriptionRepo.searchByPatientName(name);
+    }
+
 }


### PR DESCRIPTION
This Pull Request addresses issue #18 by adding the required functionality

- Added "/api/prescriptions/search" endpoint in the prescription controller 
- Checks if query parameter is present, since its required for this endpoint
- Returns a List of prescription in case a Patient has multiple prescriptions 
- Used the prescriptionRepository interface to follow project structure

Note: I couldn't find the exact fields and methods of the Prescription object. The current implementation assumes it has a Patient object with a name field and getter. If this assumption is incorrect, please let me know and I’ll make the necessary adjustments.